### PR TITLE
fix: added mising package.sh for lambda layer dependancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,7 +252,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-**/package/*
 .vscode
 
 # ignore zip packages

--- a/modules/lambda/src/package/package.sh
+++ b/modules/lambda/src/package/package.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm -rf python
+rm -rf layer.zip
+python3 -m pip install requests==2.28.2 urllib3==1.26.15 -U -t python


### PR DESCRIPTION
*Issue #, if available:* Missing Lambda layer package script
*Description of changes:*
- Added missing lambda layer package.sh
- updated `.gitignore` to not ignore `**/package/**`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
